### PR TITLE
Add REX spymode

### DIFF
--- a/browser-extension.user.js
+++ b/browser-extension.user.js
@@ -63,6 +63,14 @@
             text-decoration: none;
         }
 
+        #rex-spymode {
+            position: fixed;
+            bottom: 0;
+            right: 0;
+            background-color: rgba(255,255,255,.8);
+            padding: 1rem;
+            border: 1px dashed #000;
+        }
         /* Each REX spymode item should be on a separate line and have padding below */
         #rex-spymode > * {
             display: block;
@@ -111,10 +119,11 @@
         Array.from(window.document.querySelectorAll(grandHeadingsSelector)).forEach(h => addPermalink(h, h.parentElement.parentElement.getAttribute('id')) )
     }
 
+    let keepClosed = false
     function addRexSpymode() {
         function renderSpymode() {
             // only run on REX sites
-            if (!window.__APP_STORE) {
+            if (!window.__APP_STORE || keepClosed) {
                 return
             }
 
@@ -130,7 +139,14 @@
             }
 
             const heading = document.createElement('h2')
-            heading.append('Debugging area')
+            const close = document.createElement('button')
+            close.addEventListener('click', () => {
+                keepClosed = true
+                root.innerHTML = ''
+            })
+            close.append('X')
+            heading.append(close)
+            heading.append(' Spymode')
 
             const linkToSource = document.createElement('a')
             linkToSource.setAttribute('href', 'https://github.com/openstax/qa-tools')

--- a/browser-extension.user.js
+++ b/browser-extension.user.js
@@ -6,10 +6,11 @@
 // @include https://*.cnx.org/*
 // @include https://openstax.org/*
 // @include https://*.openstax.org/*
+// @include https://rex-web*.herokuapp.com/*
 // ==/UserScript==
 
 // This is a TamperMonkey and Greasemonkey script to make it easier to QA content
-// 
+//
 // 1. Install TamperMonkey: https://www.tampermonkey.net
 // 2. Install this script: https://openstax.github.io/qa-tools/browser-extension.user.js
 //            (assuming this repo is still named "qa-tools")
@@ -61,6 +62,12 @@
             font-weight: bold;
             text-decoration: none;
         }
+
+        /* Each REX spymode item should be on a separate line and have padding below */
+        #rex-spymode > * {
+            display: block;
+            margin-bottom: 1rem;
+        }
 `
 
     window.document.head.appendChild(style)
@@ -104,8 +111,67 @@
         Array.from(window.document.querySelectorAll(grandHeadingsSelector)).forEach(h => addPermalink(h, h.parentElement.parentElement.getAttribute('id')) )
     }
 
+    function addRexSpymode() {
+        function renderSpymode() {
+            // only run on REX sites
+            if (!window.__APP_STORE) {
+                return
+            }
+
+            const state = window.__APP_STORE.getState().content
+
+            let root = document.querySelector('#rex-spymode')
+            if (root) {
+                root.innerHTML = ''
+            } else {
+                root = document.createElement('div')
+                root.setAttribute('id', 'rex-spymode')
+                document.body.append(root)
+            }
+
+            const heading = document.createElement('h2')
+            heading.append('Debugging area')
+
+            const linkToSource = document.createElement('a')
+            linkToSource.setAttribute('href', 'https://github.com/openstax/qa-tools')
+            linkToSource.setAttribute('target', '_window')
+            linkToSource.append('Source Code for this debugging info')
+
+            const rerender = document.createElement('button')
+            rerender.append('Update')
+            rerender.addEventListener('click', renderSpymode)
+
+            const bookVerText = document.createElement('p')
+            bookVerText.append(`Book Version: ${state.book.version}`)
+
+            const linkToCnx = document.createElement('a')
+            linkToCnx.setAttribute('href', `https://vendor.cnx.org/contents/${state.book.id}@${state.book.version}:${state.page.id}`)
+            linkToCnx.setAttribute('target', '_window')
+            linkToCnx.append(`See "${state.page.title}" on Cnx`)
+
+            const linkToArchive = document.createElement('a')
+            linkToArchive.setAttribute('href', `https://archive.cnx.org/contents/${state.book.id}@${state.book.version}:${state.page.id}`)
+            linkToArchive.setAttribute('target', '_window')
+            linkToArchive.append(`See "${state.page.title}" on Archive`)
+
+            root.append(heading)
+            root.append(bookVerText)
+            root.append(linkToCnx)
+            root.append(linkToArchive)
+            root.append(rerender)
+            root.append(linkToSource)
+        }
+
+        renderSpymode()
+    }
+
+    function doAllTheThings() {
+        addLinks()
+        addRexSpymode()
+    }
+
     // Loop because SinglePageApps reload the content
-    setInterval(addLinks, 5 * 1000)
-    addLinks()
+    setInterval(doAllTheThings, 5 * 1000)
+    doAllTheThings()
 
 })();


### PR DESCRIPTION
This adds a few useful links to the bottom of every REX page:

- the current book version
- a link to CNX
- a link to CNX Archive

# TODO

- [x] update the link to CNX and archive when the browser URL contains a # target to a specific element

# Screenshot

![image](https://user-images.githubusercontent.com/253202/89323538-77dbb480-d64b-11ea-8d6a-ebf6a67f5af3.png)
