### PR TITLE
Fix link to Webhosting URL when previewing content

### DIFF
--- a/browser-extension.user.js
+++ b/browser-extension.user.js
@@ -133,6 +133,8 @@
             if (!state.book) {
                 return
             }
+          
+            const queryParams = new URLSearchParams(window.location.search)
 
             let root = document.querySelector('#rex-spymode')
             if (root) {
@@ -152,6 +154,7 @@
             close.append('X')
             heading.append(close)
             heading.append(' Spymode')
+            root.append(heading)
 
             const linkToSource = document.createElement('a')
             linkToSource.setAttribute('href', 'https://github.com/openstax/qa-tools')
@@ -164,19 +167,18 @@
 
             const bookVerText = document.createElement('p')
             bookVerText.append(`Book Version: ${state.book.version}`)
+            root.append(bookVerText)
 
-            const linkToCnx = document.createElement('a')
-						if (state.book && state.page) {
+						if (state.book && state.page && !queryParams.get('archive')) {
+              const linkToCnx = document.createElement('a')
               linkToCnx.setAttribute('href', `https://vendor.cnx.org/contents/${state.book.id}@${state.book.version}:${state.page.id}`)
               linkToCnx.setAttribute('target', '_window')
               linkToCnx.append(`See "${state.page.title}" on Cnx`)
-            } else {
-              linkToCnx.append('Maybe Uh-Oh error popped up? No book/page information')
+              root.append(linkToCnx)
             }
 
-            const linkToArchive = document.createElement('a')
             if (state.book && state.page) {
-              const queryParams = new URLSearchParams(window.location.search)
+              const linkToArchive = document.createElement('a')
               let archiveRoot = 'https://archive.cnx.org'
               let extension = ''
               let archiveName = 'Archive (old)'
@@ -188,14 +190,9 @@
               linkToArchive.setAttribute('href', `${archiveRoot}/contents/${state.book.id}@${state.book.version}:${state.page.id}${extension}`)
               linkToArchive.setAttribute('target', '_window')
               linkToArchive.append(`See "${state.page.title}" on ${archiveName}`)
-            } else {
-              linkToCnx.append('Maybe Uh-Oh error popped up? No book/page information')
+              root.append(linkToArchive)
             }
-          
-            root.append(heading)
-            root.append(bookVerText)
-            root.append(linkToCnx)
-            root.append(linkToArchive)
+
             root.append(rerender)
             root.append(linkToSource)
         }

--- a/browser-extension.user.js
+++ b/browser-extension.user.js
@@ -169,28 +169,28 @@
             bookVerText.append(`Book Version: ${state.book.version}`)
             root.append(bookVerText)
 
-						if (state.book && state.page && !queryParams.get('archive')) {
-              const linkToCnx = document.createElement('a')
-              linkToCnx.setAttribute('href', `https://vendor.cnx.org/contents/${state.book.id}@${state.book.version}:${state.page.id}`)
-              linkToCnx.setAttribute('target', '_window')
-              linkToCnx.append(`See "${state.page.title}" on Cnx`)
-              root.append(linkToCnx)
+            if (state.book && state.page && !queryParams.get('archive')) {
+                const linkToCnx = document.createElement('a')
+                linkToCnx.setAttribute('href', `https://vendor.cnx.org/contents/${state.book.id}@${state.book.version}:${state.page.id}`)
+                linkToCnx.setAttribute('target', '_window')
+                linkToCnx.append(`See "${state.page.title}" on Cnx`)
+                root.append(linkToCnx)
             }
 
             if (state.book && state.page) {
-              const linkToArchive = document.createElement('a')
-              let archiveRoot = 'https://archive.cnx.org'
-              let extension = ''
-              let archiveName = 'Archive (old)'
-              if (queryParams.get('archive')) {
-                archiveRoot = queryParams.get('archive')
-                extension = '.xhtml'
-                archiveName = 'S3 (preview)'
-              }
-              linkToArchive.setAttribute('href', `${archiveRoot}/contents/${state.book.id}@${state.book.version}:${state.page.id}${extension}`)
-              linkToArchive.setAttribute('target', '_window')
-              linkToArchive.append(`See "${state.page.title}" on ${archiveName}`)
-              root.append(linkToArchive)
+                const linkToArchive = document.createElement('a')
+                let archiveRoot = 'https://archive.cnx.org'
+                let extension = ''
+                let archiveName = 'Archive (old)'
+                if (queryParams.get('archive')) {
+                    archiveRoot = queryParams.get('archive')
+                    extension = '.xhtml'
+                    archiveName = 'S3 (preview)'
+                }
+                linkToArchive.setAttribute('href', `${archiveRoot}/contents/${state.book.id}@${state.book.version}:${state.page.id}${extension}`)
+                linkToArchive.setAttribute('target', '_window')
+                linkToArchive.append(`See "${state.page.title}" on ${archiveName}`)
+                root.append(linkToArchive)
             }
 
             root.append(rerender)

--- a/browser-extension.user.js
+++ b/browser-extension.user.js
@@ -166,15 +166,32 @@
             bookVerText.append(`Book Version: ${state.book.version}`)
 
             const linkToCnx = document.createElement('a')
-            linkToCnx.setAttribute('href', `https://vendor.cnx.org/contents/${state.book.id}@${state.book.version}:${state.page.id}`)
-            linkToCnx.setAttribute('target', '_window')
-            linkToCnx.append(`See "${state.page.title}" on Cnx`)
+						if (state.book && state.page) {
+              linkToCnx.setAttribute('href', `https://vendor.cnx.org/contents/${state.book.id}@${state.book.version}:${state.page.id}`)
+              linkToCnx.setAttribute('target', '_window')
+              linkToCnx.append(`See "${state.page.title}" on Cnx`)
+            } else {
+              linkToCnx.append('Maybe Uh-Oh error popped up? No book/page information')
+            }
 
             const linkToArchive = document.createElement('a')
-            linkToArchive.setAttribute('href', `https://archive.cnx.org/contents/${state.book.id}@${state.book.version}:${state.page.id}`)
-            linkToArchive.setAttribute('target', '_window')
-            linkToArchive.append(`See "${state.page.title}" on Archive`)
-
+            if (state.book && state.page) {
+              const queryParams = new URLSearchParams(window.location.search)
+              let archiveRoot = 'https://archive.cnx.org'
+              let extension = ''
+              let archiveName = 'Archive (old)'
+              if (queryParams.get('archive')) {
+                archiveRoot = queryParams.get('archive')
+                extension = '.xhtml'
+                archiveName = 'S3 (preview)'
+              }
+              linkToArchive.setAttribute('href', `${archiveRoot}/contents/${state.book.id}@${state.book.version}:${state.page.id}${extension}`)
+              linkToArchive.setAttribute('target', '_window')
+              linkToArchive.append(`See "${state.page.title}" on ${archiveName}`)
+            } else {
+              linkToCnx.append('Maybe Uh-Oh error popped up? No book/page information')
+            }
+          
             root.append(heading)
             root.append(bookVerText)
             root.append(linkToCnx)


### PR DESCRIPTION
When **previewing** content, REX pulls from an S3 bucket with a code version, not archive.

This is a "hack" to fix the archive link. Once REX uses the Webhosting pipeline it will be good to always link to the S3 bucket but REX does not provide that information yet.

![image](https://user-images.githubusercontent.com/253202/110000576-152dc280-7cd9-11eb-8944-bdd228e3c616.png)

Example link: https://openstax.org/apps/archive/20210224.204120/contents/16ab5b96-4598-45f9-993c-b8d78d82b0c6@5.1:46afde4f-402d-4b5a-a035-112217f55221.xhtml